### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/arma3tools.yaml
+++ b/.github/workflows/arma3tools.yaml
@@ -1,11 +1,14 @@
 name: Arma 3 Tools
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
       toolsUrl:
-        description: URL to hosted ZIP file with Arma 3 Tools
-        required: true
+       description: URL to hosted ZIP file with Arma 3 Tools
+       required: true
 
 jobs:
   install_arma3_tools:


### PR DESCRIPTION
Potential fix for [https://github.com/UKSFTA/UKSFTA-Mods/security/code-scanning/1](https://github.com/UKSFTA/UKSFTA-Mods/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow does not interact with the repository contents or perform any actions requiring write access, we will set `contents: read` as the minimal permission. This ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
