### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
 jobs:
   build_addon:
     runs-on: windows-2022
@@ -38,6 +40,9 @@ jobs:
         retention-days: 7
 
   release_addon:
+    permissions:
+      contents: write
+      packages: read
     runs-on: ubuntu-latest
     needs: build_addon
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/UKSFTA/UKSFTA-Mods/security/code-scanning/5](https://github.com/UKSFTA/UKSFTA-Mods/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow to explicitly define the required permissions for each job. The `build_addon` job primarily interacts with Docker and uploads artifacts, so it only needs `contents: read` and `actions: read`. The `release_addon` job uploads releases to GitHub and Steam Workshop, so it requires `contents: read`, `packages: read`, and `contents: write` for GitHub release creation. This ensures that the workflow has the minimal permissions necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
